### PR TITLE
Don't throw when common path is a drive root

### DIFF
--- a/src/CoberturaConverter.Core/DotCover/DotCoverBaseDirectoryFinder.cs
+++ b/src/CoberturaConverter.Core/DotCover/DotCoverBaseDirectoryFinder.cs
@@ -44,6 +44,11 @@ namespace CoberturaConverter.Core.DotCover
 
             commonStart = Path.GetDirectoryName(commonStart);
 
+            if (string.IsNullOrWhiteSpace(commonStart))
+            {
+                return string.Empty;
+            }
+
             return commonStart
                 .TrimEnd('/')
                 .TrimEnd('\\');

--- a/test/CoberturaConverter.Core.Tests/DotCover/DotCoverBaseDirectoryFinderTests.cs
+++ b/test/CoberturaConverter.Core.Tests/DotCover/DotCoverBaseDirectoryFinderTests.cs
@@ -50,6 +50,14 @@ namespace CoberturaConverter.Core.Tests.DotCover
             },
             new object[]
             {
+                string.Empty, new[]
+                {
+                    "C:\\Build\\StringEncryptionExtensions.cs",
+                    "C:\\XUnit\\XUnit.cs"
+                }
+            },
+            new object[]
+            {
                 string.Empty, new string[0]
             }
         };


### PR DESCRIPTION
Hi! Thank you very much for your great project.

I'm building inside a docker container and thus have a slightly scrappy directory layout. This includes my code in a dir `C:\BUILD` and a reference to XUnit, which seems to have been built in `C:\dev`.

Thus, the shared root is `C:\` and this causes an exception inside the Cobertura converter for DotCover.

I shouldn't really be including the XUnit assemblies in my build so I have a workaround; but it's been a bit of a trial to understand the problem so I thought i'd put in a PR along with accompanying test which I hope explains the problem a little bit better than this prose.

Thanks again!